### PR TITLE
Reentrant lock

### DIFF
--- a/lib/request_locals.rb
+++ b/lib/request_locals.rb
@@ -28,7 +28,7 @@ class RequestLocals
   end
 
   # Create cache using reentrant mutex. That's fetch call to be nested.
-  class Cache < Concurrent::Collection::MriMapBackend
+  class RequestCache < Concurrent::Map
     def initialize(options = nil)
       super(options)
       @write_lock = Monitor.new
@@ -39,7 +39,7 @@ class RequestLocals
   def_delegators :store, :[], :[]=, :delete, :empty?
 
   def initialize
-    @cache = Cache.new
+    @cache = RequestCache.new
   end
 
   # Public: Removes all the request-local variables.
@@ -53,7 +53,7 @@ class RequestLocals
   #
   # Returns nothing.
   def clear_all!
-    @cache = Cache.new
+    @cache = RequestCache.new
   end
 
   # Public: Checks if a value was stored for the given key.
@@ -92,6 +92,6 @@ protected
   # Internal: Returns a new empty structure where the request-local variables
   # will be stored.
   def new_store
-    Cache.new
+    RequestCache.new
   end
 end

--- a/lib/request_locals.rb
+++ b/lib/request_locals.rb
@@ -1,6 +1,6 @@
 require 'singleton'
 require 'forwardable'
-require 'thread_safe'
+require 'concurrent'
 
 # Public: Provides per-request global storage, by offering an interface that is
 # very similar to Rails.cache, or Hash.
@@ -27,11 +27,19 @@ class RequestLocals
     private :instance
   end
 
+  # Create cache using reentrant mutex. That's fetch call to be nested.
+  class Cache < Concurrent::Collection::MriMapBackend
+    def initialize(options = nil)
+      super(options)
+      @write_lock = Monitor.new
+    end
+  end
+
   # Internal: Methods of the RequestLocals instance, delegated to the request-local structure.
   def_delegators :store, :[], :[]=, :delete, :empty?
 
   def initialize
-    @cache = ThreadSafe::Cache.new
+    @cache = Cache.new
   end
 
   # Public: Removes all the request-local variables.
@@ -45,7 +53,7 @@ class RequestLocals
   #
   # Returns nothing.
   def clear_all!
-    @cache = ThreadSafe::Cache.new
+    @cache = Cache.new
   end
 
   # Public: Checks if a value was stored for the given key.
@@ -84,6 +92,6 @@ protected
   # Internal: Returns a new empty structure where the request-local variables
   # will be stored.
   def new_store
-    ThreadSafe::Cache.new
+    Cache.new
   end
 end

--- a/request_store_rails.gemspec
+++ b/request_store_rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest', '~> 5.0'
 
-  s.add_runtime_dependency 'thread_safe', ['~> 0.3', '>= 0.3.5']
+  s.add_runtime_dependency 'concurrent-ruby', ['~> 1.0.0']
 end

--- a/test/request_locals_test.rb
+++ b/test/request_locals_test.rb
@@ -94,6 +94,11 @@ class RequestLocalsTest < Minitest::Unit::TestCase
     assert_nil global_store[:different_id]
   end
 
+  def test_nested_fetch
+    RequestLocals.clear!
+    assert_equal 2, RequestLocals.store.fetch(:bar) { 1 + RequestLocals.fetch(:foo){ 1 } }
+    assert_equal 2, RequestLocals.store.fetch(:bar) { 1 + RequestLocals.fetch(:foo){ 1 } }
+  end
 private
 
   def global_store


### PR DESCRIPTION
Hi,

I need to make nested call to RequestLocals.fetch. This can't be done with previous version because Cache implementation used relied on Mutex which doesn't allow reentrant lock in Ruby.

I just create a new Cache class base on Collection::Map from ruby-concurrent gem and change Mutex to Monitor in it implementation